### PR TITLE
Pin jsonfeed 1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 install:
 	pip3 install -r requirements.txt
 
+lint:
+	flake8 . --count --max-complexity=10 --statistics
+
 run:
 	dev_appserver.py --port=8080 app.yaml
 

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def json(all):
         favicon="https://arxiv-feeds.appspot.com/favicons/favicon.ico",
         items=[toFeedEntry(item) for item in items]
     )
-    return feed.toJSON(indent="\t")
+    return feed.to_json(indent="\t")
 
 
 # Serve Atom feeds.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arxiv==1.0.0
 bottle==0.12.20
 google-cloud-logging==1.12.1
-git+https://github.com/lukasschwab/jsonfeed.git#egg=jsonfeed
+git+https://github.com/lukasschwab/jsonfeed.git@1.0.0#egg=jsonfeed
 pytz==2019.1


### PR DESCRIPTION
## Changes

+ Explicitly pins `jsonfeed` tag 1.0.0 instead of default (latest).
+ Updates `jsonfeed` usage for 1.0.0 API.

## Motivation

Latest `jsonfeed` broke redeploy.

## Testing

JSON feed works in `make run` local app.